### PR TITLE
fix(flatten_authors): fallback to 'last_known_institutions' for institution id extraction (tested on Python 3.11.8)

### DIFF
--- a/flatten-openalex-jsonl.py
+++ b/flatten-openalex-jsonl.py
@@ -292,8 +292,11 @@ def flatten_authors():
                         author.get('display_name_alternatives'),
                         ensure_ascii=False)
                     author['last_known_institution'] = (
-                        author.get('last_known_institutions') or author.get('last_known_institution') or {}
-                        ).get('id')
+                        (author.get('last_known_institutions')[0] 
+                         if isinstance(author.get('last_known_institutions'), list) 
+                         and author.get('last_known_institutions') 
+                         else author.get('last_known_institution')) or {}
+                    ).get('id')
 
                     authors_writer.writerow(author)
 

--- a/flatten-openalex-jsonl.py
+++ b/flatten-openalex-jsonl.py
@@ -292,8 +292,9 @@ def flatten_authors():
                         author.get('display_name_alternatives'),
                         ensure_ascii=False)
                     author['last_known_institution'] = (
-                                author.get('last_known_institution') or {}).get(
-                        'id')
+                        author.get('last_known_institutions') or author.get('last_known_institution') or {}
+                        ).get('id')
+
                     authors_writer.writerow(author)
 
                     # ids


### PR DESCRIPTION
This PR updates `flatten_authors` to handle cases where the source uses 'last_known_institutions' instead of 'last_known_institution'. If 'last_known_institutions' exists and is a non-empty list, the function extracts the 'id' from its first element. Else, it falls back to 'last_known_institutions' or {}.

This change prevents most 'last_known_institution' entries in authors.csv from being null.

(Python 3.11.8)
